### PR TITLE
Check for MEI interface at both /dev/mei0 and /dev/mei.

### DIFF
--- a/mei-amt-check.c
+++ b/mei-amt-check.c
@@ -115,12 +115,18 @@ static bool mei_init(struct mei *me, const uuid_le *guid,
 	int result;
 	struct mei_client *cl;
 	struct mei_connect_client_data data;
+	char *errmsg;
 
 	me->verbose = verbose;
 
+	errmsg = "Cannot open /dev/mei0";
 	me->fd = open("/dev/mei0", O_RDWR);
+	if (me->fd == -1 && errno == ENOENT) {
+		errmsg = "Cannot open /dev/mei";
+		me->fd = open("/dev/mei", O_RDWR);
+	}
 	if (me->fd == -1) {
-		perror("Cannot open /dev/mei0");
+		perror(errmsg);
 		goto err;
 	}
 	memcpy(&me->guid, guid, sizeof(*guid));


### PR DESCRIPTION
Also, make sure that an error on open (e.g., EPERM if not run as root)
is reported with the /dev filename that we actually tried.

Resolves issue #3 -- "Cannot open /dev/mei0".  At least on machines where
the driver manifests instead as /dev/mei ...