### PR TITLE
Remove direct inclusion of <bits/wordsize.h>

### DIFF
--- a/mei-amt-check.c
+++ b/mei-amt-check.c
@@ -75,7 +75,6 @@
 #include <errno.h>
 #include <stdint.h>
 #include <stdbool.h>
-#include <bits/wordsize.h>
 #include <linux/mei.h>
 
 /*****************************************************************************


### PR DESCRIPTION
This allows building on non-glibc systems such as musl, and wordsize.h
is included via stdint.h anyway.